### PR TITLE
Reduce the size of the npm download by 50%

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test
+README.md


### PR DESCRIPTION
NPM package doesn't need test folder (28K) or README.md (10K). By excluding those from publishing to npm, the size of the package becomes half of what it was. Why not?